### PR TITLE
유저 생성 어드민 API 구현

### DIFF
--- a/src/main/java/com/simleetag/homework/api/domain/user/User.java
+++ b/src/main/java/com/simleetag/homework/api/domain/user/User.java
@@ -35,6 +35,12 @@ public class User extends DeletableEntity {
         this.oauthId = oauthId;
     }
 
+    public User(String oauthId, String profileImage, String userName) {
+        this.oauthId = oauthId;
+        this.profileImage = profileImage;
+        this.userName = userName;
+    }
+
     public void editProfile(UserProfileRequest request) {
         this.userName = request.userName();
         this.profileImage = request.profileImage();

--- a/src/main/java/com/simleetag/homework/api/domain/user/UserService.java
+++ b/src/main/java/com/simleetag/homework/api/domain/user/UserService.java
@@ -1,5 +1,6 @@
 package com.simleetag.homework.api.domain.user;
 
+import com.simleetag.homework.api.domain.user.api.UserSignUpRequest;
 import com.simleetag.homework.api.domain.user.api.dto.UserProfileRequest;
 import com.simleetag.homework.api.domain.user.repository.UserRepository;
 
@@ -23,5 +24,10 @@ public class UserService {
         final var user = findById(userId);
         user.editProfile(request);
         return user;
+    }
+
+    public User add(UserSignUpRequest request) {
+        User user = new User(request.oauthId(), request.profileImage(), request.userName());
+        return userRepository.save(user);
     }
 }

--- a/src/main/java/com/simleetag/homework/api/domain/user/api/UserMaintenanceController.java
+++ b/src/main/java/com/simleetag/homework/api/domain/user/api/UserMaintenanceController.java
@@ -1,5 +1,7 @@
 package com.simleetag.homework.api.domain.user.api;
 
+import com.simleetag.homework.api.domain.user.UserService;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,10 +17,11 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/maintenance")
 public class UserMaintenanceController {
+    private final UserService userService;
 
-    @Operation(summary = "테스트 API")
+    @Operation(summary = "생성")
     @GetMapping
-    public ResponseEntity<String> helloWorld() {
-        return ResponseEntity.ok("Hello world!");
+    public ResponseEntity<Long> signUp(UserSignUpRequest request) {
+        return ResponseEntity.ok(userService.add(request).getId());
     }
 }

--- a/src/main/java/com/simleetag/homework/api/domain/user/api/UserSignUpRequest.java
+++ b/src/main/java/com/simleetag/homework/api/domain/user/api/UserSignUpRequest.java
@@ -1,0 +1,8 @@
+package com.simleetag.homework.api.domain.user.api;
+
+public record UserSignUpRequest(
+        String oauthId,
+        String profileImage,
+        String userName
+) {
+}

--- a/src/main/java/com/simleetag/homework/utils/DBInitializer.java
+++ b/src/main/java/com/simleetag/homework/utils/DBInitializer.java
@@ -4,12 +4,8 @@ import java.util.Arrays;
 
 import com.simleetag.homework.api.domain.home.api.HomeController;
 import com.simleetag.homework.api.domain.home.api.dto.CreateHomeRequest;
-import com.simleetag.homework.api.domain.user.api.UserController;
-import com.simleetag.homework.api.domain.user.api.dto.UserProfileRequest;
-import com.simleetag.homework.api.domain.user.oauth.ProviderType;
-import com.simleetag.homework.api.domain.user.oauth.api.OAuthController;
-import com.simleetag.homework.api.domain.user.oauth.api.dto.TokenRequest;
-import com.simleetag.homework.api.domain.user.oauth.api.dto.TokenResponse;
+import com.simleetag.homework.api.domain.user.api.UserMaintenanceController;
+import com.simleetag.homework.api.domain.user.api.UserSignUpRequest;
 import com.simleetag.homework.api.domain.work.CategoryType;
 import com.simleetag.homework.api.domain.work.api.*;
 import com.simleetag.homework.api.domain.work.task.api.TaskCreateRequest;
@@ -30,9 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DBInitializer implements CommandLineRunner {
     // user
-    private final OAuthController oauthController;
-
-    private final UserController userController;
+    private final UserMaintenanceController userMaintenanceController;
 
     // home
     private final HomeController homeController;
@@ -46,17 +40,13 @@ public class DBInitializer implements CommandLineRunner {
 
     private Long homeId;
 
-    private String homeworkToken;
-
     private Long userId;
 
     @Override
     public void run(String... args) {
         // 유저 생성 및 정보 수정
-        final TokenResponse user = oauthController.login(new TokenRequest("a.b.c", ProviderType.KAKAO)).getBody();
-        homeworkToken = user.homeworkToken();
-        userId = user.user().userId();
-        userController.editProfile(userId, new UserProfileRequest("에버", "image.com"));
+        userId = userMaintenanceController.signUp(
+                new UserSignUpRequest("dummy-oauth-id", "image.com", "ever")).getBody();
 
         // 집 생성 및 입장
         homeId = homeController.createHome(userId, new CreateHomeRequest("백엔드 집")).getBody().homeId();


### PR DESCRIPTION
더미 데이터 생성 시 OAuth 때문에 실패하여 런타임에러가 나기에 어드민 API를 만들었습니다.

### OAuth 실패 이유
1. 더미 유저 생성을 OAuth로 회원가입을 시켜서 하고 있습니다.
2. OAuth 회원 가입은 iOS가 주는 Authorize 토큰이 유효한 경우에만 진행됩니다. 즉, 웹 화면에서 GitHub 혹은 카카오로 로그인해야만 Authorize 토큰이 발급됩니다. 
3. 그러므로 백엔드에서는 Authorize 토큰을 자동으로 발급받을 수 없습니다.
4. 그러므로 백엔드에서 OAuth로 유저를 생성할 수 없습니다.