### PR TITLE
유저와 집 ID로 멤버 ID 조회하는 기능 구현

### DIFF
--- a/src/main/java/com/simleetag/homework/api/domain/home/api/HomeMaintenanceController.java
+++ b/src/main/java/com/simleetag/homework/api/domain/home/api/HomeMaintenanceController.java
@@ -40,7 +40,7 @@ public class HomeMaintenanceController {
 
     @Operation(summary = "생성")
     @PostMapping
-    public ResponseEntity<HomeResponse> create(EmptyHomeCreateRequest request) {
+    public ResponseEntity<HomeResponse> create(@RequestBody EmptyHomeCreateRequest request) {
         final Home home = homeService.createEmptyHome(request);
         return ResponseEntity.ok(HomeResponse.from(home));
     }

--- a/src/main/java/com/simleetag/homework/api/domain/home/member/MemberFinder.java
+++ b/src/main/java/com/simleetag/homework/api/domain/home/member/MemberFinder.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberFinder {
 
     private static final String NOT_FOUND_MESSAGE = "MemberID[%d]를 가진 멤버가 존재하지 않습니다.";
+    private static final String NOT_FOUND_GENERAL_MESSAGE = "해당 멤버가 존재하지 않습니다.";
 
     private final MemberRepository memberRepository;
 
@@ -33,5 +34,10 @@ public class MemberFinder {
 
     public List<Member> findAllByHomeId(Long homeId) {
         return memberRepository.findAllByHomeId(homeId);
+    }
+
+    public Member findByHomeIdAndUserId(Long homeId, Long userId) {
+        return memberRepository.findByHomeIdAndUserIdAndDeletedAtIsNull(homeId, userId)
+                                  .orElseThrow(() -> new IllegalArgumentException(String.format(NOT_FOUND_GENERAL_MESSAGE)));
     }
 }

--- a/src/main/java/com/simleetag/homework/api/domain/home/member/api/MemberController.java
+++ b/src/main/java/com/simleetag/homework/api/domain/home/member/api/MemberController.java
@@ -1,11 +1,17 @@
 package com.simleetag.homework.api.domain.home.member.api;
 
-import com.simleetag.homework.api.domain.home.HomeFinder;
-import com.simleetag.homework.api.domain.home.member.MemberService;
+import com.simleetag.homework.api.common.Login;
+import com.simleetag.homework.api.domain.home.member.Member;
+import com.simleetag.homework.api.domain.home.member.MemberFinder;
+import com.simleetag.homework.api.domain.home.member.dto.MemberIdResponse;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
@@ -16,8 +22,18 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/members")
 public class MemberController {
 
-    private final MemberService memberService;
+    private final MemberFinder memberFinder;
 
-    private final HomeFinder homeFinder;
+    @Operation(
+            summary = "유저의 멤버 id 조회",
+            description = """
+                    해당 유저의 해당 집의 멤버 id를 조회합니다.
+                    """
+    )
+    @GetMapping
+    public ResponseEntity<MemberIdResponse> findMemberId(@Login Long userId, @RequestParam Long homeId) {
+        final Member member = memberFinder.findByHomeIdAndUserId(homeId, userId);
+        return ResponseEntity.ok(new MemberIdResponse(member.getId()));
+    }
 
 }

--- a/src/main/java/com/simleetag/homework/api/domain/home/member/repository/MemberRepository.java
+++ b/src/main/java/com/simleetag/homework/api/domain/home/member/repository/MemberRepository.java
@@ -1,12 +1,15 @@
 package com.simleetag.homework.api.domain.home.member.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.simleetag.homework.api.domain.home.member.Member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByHomeIdAndUserIdAndDeletedAtIsNull(Long homeId, Long userId);
 
     List<Member> findAllByHomeId(Long homeId);
 }

--- a/src/main/java/com/simleetag/homework/api/domain/user/api/UserMaintenanceController.java
+++ b/src/main/java/com/simleetag/homework/api/domain/user/api/UserMaintenanceController.java
@@ -33,7 +33,7 @@ public class UserMaintenanceController {
 
     @Operation(summary = "생성")
     @PostMapping
-    public ResponseEntity<Long> signUp(UserSignUpRequest request) {
+    public ResponseEntity<Long> signUp(@RequestBody UserSignUpRequest request) {
         return ResponseEntity.ok(userService.add(request).getId());
     }
 

--- a/src/test/java/com/simleetag/homework/api/domain/home/member/MemberControllerFlow.java
+++ b/src/test/java/com/simleetag/homework/api/domain/home/member/MemberControllerFlow.java
@@ -1,12 +1,33 @@
 package com.simleetag.homework.api.domain.home.member;
 
+import java.nio.charset.StandardCharsets;
+
 import com.simleetag.homework.api.common.FlowSupport;
+import com.simleetag.homework.api.common.IdentifierHeader;
+import com.simleetag.homework.api.domain.home.member.dto.MemberIdResponse;
 
 import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class MemberControllerFlow extends FlowSupport {
     public MemberControllerFlow(MockMvc mockMvc) {
         super(mockMvc);
     }
+
+    public MemberIdResponse findMemberId(String homeworkToken, Long homeId) throws Exception {
+        final String responseBody = mockMvc.perform(
+                                                   get("/api/members")
+                                                           .param("homeId", String.valueOf(homeId))
+                                                           .header(IdentifierHeader.USER.getKey(), homeworkToken)
+                                           ).andExpect(
+                                                   status().isOk()
+                                           ).andReturn()
+                                           .getResponse()
+                                           .getContentAsString(StandardCharsets.UTF_8);
+        return objectMapper.readValue(responseBody, MemberIdResponse.class);
+    }
+
 
 }

--- a/src/test/java/com/simleetag/homework/api/domain/home/member/MemberControllerTest.java
+++ b/src/test/java/com/simleetag/homework/api/domain/home/member/MemberControllerTest.java
@@ -1,7 +1,82 @@
 package com.simleetag.homework.api.domain.home.member;
 
 import com.simleetag.homework.api.common.TestSupport;
+import com.simleetag.homework.api.domain.home.api.HomeControllerFlow;
+import com.simleetag.homework.api.domain.home.api.dto.CreatedHomeResponse;
+import com.simleetag.homework.api.domain.home.api.dto.HomeCreateRequest;
+import com.simleetag.homework.api.domain.home.member.dto.MemberIdResponse;
+import com.simleetag.homework.api.domain.user.api.UserControllerFlow;
+import com.simleetag.homework.api.domain.user.api.dto.UserProfileRequest;
+import com.simleetag.homework.api.domain.user.oauth.ProviderType;
+import com.simleetag.homework.api.domain.user.oauth.api.OAuthControllerFlow;
+import com.simleetag.homework.api.domain.user.oauth.api.dto.TokenRequest;
+import com.simleetag.homework.api.domain.user.oauth.api.dto.TokenResponse;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class MemberControllerTest extends TestSupport {
+
+    private MemberControllerFlow memberController;
+
+    private HomeControllerFlow homeController;
+
+    private String homeworkToken;
+
+    private Long userId;
+
+    private Long homeId;
+
+    private OAuthControllerFlow oauthController;
+
+    private UserControllerFlow userController;
+
+
+    @BeforeAll
+    public void init() {
+        oauthController = new OAuthControllerFlow(mockMvc);
+        userController = new UserControllerFlow(mockMvc);
+        homeController = new HomeControllerFlow(mockMvc);
+        memberController = new MemberControllerFlow(mockMvc);
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // 에버 유저 생성
+        var loginRequest = new TokenRequest("a.b.c", ProviderType.KAKAO);
+        final TokenResponse ever = oauthController.login(loginRequest);
+
+        homeworkToken = ever.homeworkToken();
+        userId = ever.user().userId();
+
+        // 에버 정보 수정
+        final UserProfileRequest everProfile = new UserProfileRequest("에버", "https://image.com");
+        userController.editProfile(ever.homeworkToken(), everProfile);
+
+        final String homeName = "백엔드집";
+        final HomeCreateRequest request = new HomeCreateRequest(homeName);
+        final CreatedHomeResponse home = homeController.createHome(homeworkToken, request);
+        homeId = home.homeId();
+    }
+
+    @Test
+    @DisplayName("집 아이디와 유저 아이디로 멤버 아이디 조회 성공 테스트")
+    void findMemberByHomeIdAndUserId() throws Exception {
+
+        // given
+        // 집 들어가기(멤버 추가)
+        MemberIdResponse memberIdResponse = homeController.joinHome(homeId, homeworkToken);
+
+        // when
+        MemberIdResponse findMemberId = memberController.findMemberId(homeworkToken, homeId);
+
+        // then
+        assertThat(memberIdResponse.memberId()).isEqualTo(findMemberId.memberId());
+    }
+
 
 }


### PR DESCRIPTION
### 요구 사항
- [x] `@RequestBody` 빠진 부분 추가
- [x] 유저와 집 ID로 멤버 ID 조회하는 기능 구현
	- 메인 화면 접근 시 유저 ID와 집 ID로 멤버 ID 조회해서 사용할 수 있도록 함